### PR TITLE
`serialize-impl` feature on `diffus-derive`.

### DIFF
--- a/diffus-derive-test/Cargo.toml
+++ b/diffus-derive-test/Cargo.toml
@@ -27,4 +27,4 @@ serde_json = { version = "1.0", optional = true }
 [features]
 default = []
 
-serialize-impl = [ "serde", "serde_json" ]
+serialize-impl = [ "diffus-derive/serialize-impl", "serde", "serde_json" ]

--- a/diffus-derive/Cargo.toml
+++ b/diffus-derive/Cargo.toml
@@ -31,3 +31,6 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
+
+[features]
+serialize-impl = []


### PR DESCRIPTION
Previously, `diffus-derive` generated
`#[cfg_attr(feature = "serialize-impl", derive(serde::Serialize))]`
which caused the evaluation of the expression to be performed when
`#[derive(Diffable)]` was evaluated, i.e. in the end-users project.

This change introduces the `serialize-impl` feature in `diffus-derive`
so that a `#[derive(serde::Serialize)]` is put on `Edited*` types
whenever the end-user is using `#[derive(Diffable)]`.

closes https://github.com/distil/diffus/issues/46