### PR TITLE
ci: add travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+cache: cargo
+dist: focal
+language: rust
+rust:
+  - beta
+  - stable
+  - 1.37.0
+
+before_install: rustup component add rustfmt
+script: ./test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Internal
+
+- Added Travis CI. MSRV is 1.37.0 (#60, @tommilligan)


### PR DESCRIPTION
Closes #60 

I'm been looking at integrating `diffus` into the [`pretty_assertions`](https://github.com/colin-kiegel/rust-pretty-assertions/) crate, and couldn't find the MSRV documented anywhere - this PR adds [Travis CI](https://travis-ci.com/) for the current MSRV of 1.37.0 (when [type alias enum variants](https://github.com/rust-lang/rust/pull/61682) were stabilised).

[Travis CI](https://travis-ci.com/) is fee for open source projects and is widely used in the community. If you would prefer me to set up a different provider, I'm happy to update my PR.

You can see the build output of this branch [here](https://travis-ci.com/github/tommilligan/diffus/builds/216297318)